### PR TITLE
Track any element via appEvent

### DIFF
--- a/javascripts/discourse-media-events/lib/track-cooked-media-events.js.es6
+++ b/javascripts/discourse-media-events/lib/track-cooked-media-events.js.es6
@@ -10,11 +10,11 @@ export default class MediaEventTracker {
     const videoElements = postElement.querySelectorAll("video");
     const audioElements = postElement.querySelectorAll("audio");
 
-    videoElements.forEach(this._bindMediaEvents.bind(this));
-    audioElements.forEach(this._bindMediaEvents.bind(this));
+    videoElements.forEach(this.bindMediaEvents.bind(this));
+    audioElements.forEach(this.bindMediaEvents.bind(this));
   }
 
-  _bindMediaEvents(mediaElement) {
+  bindMediaEvents(mediaElement) {
     TRACKED_EVENTS.forEach((eventType) => {
       mediaElement.addEventListener(eventType, (event) => {
         this._updateLastTime(event.target);

--- a/javascripts/discourse/initializers/discourse-media-events.js.es6
+++ b/javascripts/discourse/initializers/discourse-media-events.js.es6
@@ -21,7 +21,7 @@ export default {
       );
       appEvents.on("discourse-media:start-tracking-video", (videoElement) => {
         tracker.bindMediaEvents(videoElement);
-      })
+      });
     });
   },
 };

--- a/javascripts/discourse/initializers/discourse-media-events.js.es6
+++ b/javascripts/discourse/initializers/discourse-media-events.js.es6
@@ -19,6 +19,9 @@ export default {
           id: "discourse-media-events",
         }
       );
+      appEvents.on("discourse-media:start-tracking-video", (videoElement) => {
+        tracker.bindMediaEvents(videoElement);
+      })
     });
   },
 };


### PR DESCRIPTION
This allows other plugins to leverage the logic in this plugin, and track custom video/audio tags that are outside of posts cooked content.