### PR TITLE
FIX: ended is a function

### DIFF
--- a/javascripts/discourse-media-events/lib/track-cooked-media-events.js
+++ b/javascripts/discourse-media-events/lib/track-cooked-media-events.js
@@ -62,7 +62,7 @@ export default class MediaEventTracker {
       ? this._extractEventDataVideojs(target)
       : this._extractEventData(target);
 
-    if (eventType === "pause" && target.ended) {
+    if (eventType === "pause" && target.ended()) {
       return;
     }
 


### PR DESCRIPTION
We have to call that function because otherwise it is always truthy

<img width="1168" alt="Screen Shot 2022-05-10 at 12 33 09 pm" src="https://user-images.githubusercontent.com/72780/167530894-9ebe9c64-c045-4b78-b524-93bbf8939158.png">

https://docs.videojs.com/docs/api/player.html#Methodsended